### PR TITLE
DOC: explain default setting for MonthlyNH3 option

### DIFF
--- a/Subrun.rst
+++ b/Subrun.rst
@@ -538,7 +538,10 @@ simpler latitude-dependent system is used (based upon DO3SE), and so
 
 ``MonthlyNH3='LOTOS'`` is also only relevant for European simulations; and
 indeed any non-European runs are better off with monthly emissions for
-that particular area.
+that particular area. To disable the monthly NH3 profile from LOTOS-EUROS
+and instead use the monthly profile defined, for example, in the 
+``MonthlyFacFile``, set ``MonthlyNH3='-'`` explicitly. If not set explicitly,
+``MonthlyNH3='LOTOS'`` will be set automatically for European simulation runs.
 
 ``CONVECTION`` is difficult. In principle, all models runs should use the T
 setting, but for Europe we find it degrades the model results too much


### PR DESCRIPTION
I recently found out that `MonthlyNH3='LOTOS'` is set automatically for European runs, overwriting any monthly factors set in the `MonthlyFacFile` for NH3. I think it would be good if this would be added to the user guide, so I'm now sending you a proposed a change. Please let me know if you agree / would like to make changes to it. Thanks & best, Ruben